### PR TITLE
Add theme toggling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { ThemeProvider } from "@/components/theme-provider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
@@ -9,19 +10,21 @@ import NotFound from "./pages/NotFound";
 const queryClient = new QueryClient();
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+  <ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  </ThemeProvider>
 );
 
 export default App;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 
 import { useState } from "react";
-import { MessageSquare, Users, MapPin, Settings, Star, CreditCard, LogOut } from "lucide-react";
+import { MessageSquare, Users, MapPin, Settings, Star, CreditCard, LogOut, Sun, Moon } from "lucide-react";
+import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -17,6 +18,7 @@ interface DashboardProps {
 
 export const Dashboard = ({ userProfile }: DashboardProps) => {
   const [activeTab, setActiveTab] = useState<'forum' | 'chat' | 'sellers' | 'profile'>('forum');
+  const { theme, setTheme } = useTheme();
   const { signOut } = useAuth();
   const { toast } = useToast();
 
@@ -75,6 +77,18 @@ export const Dashboard = ({ userProfile }: DashboardProps) => {
                 {userProfile.subscription_active ? 'Aktiv' : 'Inaktiv'}
               </Badge>
             )}
+            <Button
+              onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+              variant="ghost"
+              size="sm"
+              className="text-blue-300 hover:text-white"
+            >
+              {theme === "dark" ? (
+                <Sun className="h-4 w-4" />
+              ) : (
+                <Moon className="h-4 w-4" />
+              )}
+            </Button>
             <Button
               onClick={handleSignOut}
               variant="ghost"

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+import { ThemeProvider as NextThemeProvider } from "next-themes"
+import { PropsWithChildren } from "react"
+
+export const ThemeProvider = ({ children }: PropsWithChildren) => (
+  <NextThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    {children}
+  </NextThemeProvider>
+)


### PR DESCRIPTION
## Summary
- provide a simple `ThemeProvider` using `next-themes`
- wrap app with the new provider
- allow switching between light and dark mode from Dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68460afd40688326ada6148c6bff8c92