### PR TITLE
Fix duplicate imports in Dashboard

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,10 +1,20 @@
 
 import { useState } from "react";
 
-import { MessageSquare, Users, MapPin, Settings, Star, CreditCard, LogOut, Check } from "lucide-react";
-
-
-import { MessageSquare, Users, MapPin, Settings, Star, CreditCard, LogOut, Megaphone, Calendar, Sun, Moon, Check } from "lucide-react";
+import {
+  MessageSquare,
+  Users,
+  MapPin,
+  Settings,
+  Star,
+  CreditCard,
+  LogOut,
+  Megaphone,
+  Calendar,
+  Sun,
+  Moon,
+  Check,
+} from "lucide-react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -14,8 +24,7 @@ import { EnhancedForumList } from "@/components/EnhancedForumList";
 import { EnhancedSellerProfiles } from "@/components/EnhancedSellerProfiles";
 import { AnnouncementsFeed } from "@/components/AnnouncementsFeed";
 import { EventsCalendar } from "@/components/EventsCalendar";
-import { UserProfile } from "@/hooks/useAuth";
-import { useAuth } from "@/hooks/useAuth";
+import { useAuth, UserProfile } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 
 interface DashboardProps {


### PR DESCRIPTION
## Summary
- deduplicated lucide-react imports
- consolidated `useAuth` and `UserProfile` imports into a single statement

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: npm could not download packages)*
- `npm run lint` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684609e5cf708326a05819ccabcc4c83