### PR TITLE
Update README with env setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ git clone <YOUR_GIT_URL>
 # Step 2: Navigate to the project directory.
 cd <YOUR_PROJECT_NAME>
 
-# Step 3: Create a `.env` file with your Supabase credentials.
-cat <<EOF > .env
-VITE_SUPABASE_URL=<YOUR_SUPABASE_URL>
-VITE_SUPABASE_ANON_KEY=<YOUR_SUPABASE_ANON_KEY>
-EOF
+# Step 3: Copy `.env.example` to `.env` and fill in your Supabase credentials.
+cp .env.example .env
+# Edit `.env` and set values for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
 
 # Step 4: Install the necessary dependencies.
 npm i


### PR DESCRIPTION
## Summary
- mention copying `.env.example` to `.env`
- instruct where to set `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846d572541883269f8690bcca19b0d8