### PR TITLE
Fix profile fetch on sign in

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -102,7 +102,7 @@ export const useAuth = () => {
         .from('profiles')
         .select('*')
         .eq('id', userId)
-        .single();
+        .maybeSingle();
 
       if (profileError) {
         console.error('Profile fetch error:', profileError);
@@ -115,11 +115,13 @@ export const useAuth = () => {
           user_role: supabaseUser.user_metadata?.user_role,
           borough: supabaseUser.user_metadata?.borough,
         });
+
         const { data } = await supabase
           .from('profiles')
           .select('*')
           .eq('id', userId)
           .single();
+
         profileData = data as any;
       }
 


### PR DESCRIPTION
## Summary
- handle missing profile rows in `fetchProfile`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846d516349c83269019876a961d7b13