### PR TITLE
Implement event scraping and new forum post dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "scrape-events": "node ./scripts/scrapeBerlinEvents.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -79,6 +80,7 @@
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
+    "cheerio": "^1.0.0-rc.12",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"

--- a/public/events.json
+++ b/public/events.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "1",
+    "title": "Placeholder Event",
+    "description": "Sample event data. Run 'npm run scrape-events' to fetch real events.",
+    "event_date": "2025-07-01",
+    "location": "Berlin"
+  }
+]

--- a/scripts/scrapeBerlinEvents.js
+++ b/scripts/scrapeBerlinEvents.js
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import { load } from 'cheerio';
+
+const EVENTS_URL = 'https://www.berlin.de/en/events/';
+
+async function scrape() {
+  try {
+    const res = await fetch(EVENTS_URL);
+    const html = await res.text();
+    const $ = load(html);
+    const events = [];
+
+    $('.simple-list .simple-list__item').each((_, el) => {
+      const title = $(el).find('.simple-list__title').text().trim();
+      const date = $(el).find('.simple-list__date').text().trim();
+      const location = $(el).find('.simple-list__location').text().trim();
+      const description = $(el).find('.simple-list__teaser').text().trim();
+      if (title) {
+        events.push({
+          id: String(events.length + 1),
+          title,
+          description,
+          event_date: date,
+          location,
+        });
+      }
+    });
+
+    fs.writeFileSync('public/events.json', JSON.stringify(events, null, 2));
+    console.log(`Saved ${events.length} events.`);
+  } catch (err) {
+    console.error('Failed to scrape events:', err);
+  }
+}
+
+scrape();

--- a/src/components/BuyerDashboard.tsx
+++ b/src/components/BuyerDashboard.tsx
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { supabase } from '@/integrations/supabase/client';
+import { UserProfile } from '@/hooks/useAuth';
+
+interface Props {
+  userProfile: UserProfile;
+}
+
+export const BuyerDashboard = ({ userProfile }: Props) => {
+  const [posts, setPosts] = useState(0);
+  const [activeChats, setActiveChats] = useState(0);
+
+  useEffect(() => {
+    fetchStats();
+  }, []);
+
+  const fetchStats = async () => {
+    const { count: postCount } = await supabase
+      .from('forum_posts')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userProfile.id);
+    setPosts(postCount || 0);
+
+    const { count: chatCount } = await supabase
+      .from('chat_rooms')
+      .select('*', { count: 'exact', head: true })
+      .eq('created_by', userProfile.id);
+    setActiveChats(chatCount || 0);
+  };
+
+  return (
+    <Card className="bg-white/10 backdrop-blur-md border-white/20 text-white">
+      <CardHeader>
+        <CardTitle>Buyer Dashboard</CardTitle>
+        <CardDescription className="text-blue-200">Aktivität Übersicht</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-4 text-center">
+          <div>
+            <p className="text-sm text-blue-300">Eigene Posts</p>
+            <p className="text-2xl font-bold">{posts}</p>
+          </div>
+          <div>
+            <p className="text-sm text-blue-300">Erstellte Chats</p>
+            <p className="text-2xl font-bold">{activeChats}</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -24,6 +24,8 @@ import { EnhancedForumList } from "@/components/EnhancedForumList";
 import { EnhancedSellerProfiles } from "@/components/EnhancedSellerProfiles";
 import { AnnouncementsFeed } from "@/components/AnnouncementsFeed";
 import { EventsCalendar } from "@/components/EventsCalendar";
+import { SellerDashboard } from "@/components/SellerDashboard";
+import { BuyerDashboard } from "@/components/BuyerDashboard";
 import { useAuth, UserProfile } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 
@@ -159,56 +161,11 @@ export const Dashboard = ({ userProfile }: DashboardProps) => {
           {activeTab === 'announcements' && <AnnouncementsFeed />}
           {activeTab === 'events' && <EventsCalendar />}
           {activeTab === 'profile' && (
-            <Card className="bg-white/10 backdrop-blur-md border-white/20 text-white">
-              <CardHeader>
-                <CardTitle>Profil</CardTitle>
-                <CardDescription className="text-blue-200">
-                  Verwalten Sie Ihr Konto und Ihre Einstellungen
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  <div>
-                    <h3 className="font-semibold mb-2">Benutzerinformationen</h3>
-                    <div className="grid grid-cols-2 gap-4 text-sm">
-                      <div>
-                        <span className="text-blue-300">Nickname:</span>
-                        <span className="ml-2">{userProfile.nickname}</span>
-                      </div>
-                      <div>
-                        <span className="text-blue-300">Bezirk:</span>
-                        <span className="ml-2">{userProfile.borough}</span>
-                      </div>
-                      <div>
-                        <span className="text-blue-300">Rolle:</span>
-                        <span className="ml-2">{userProfile.user_role === 'seller' ? 'Verkäufer' : 'Käufer'}</span>
-                      </div>
-                      <div>
-                        <span className="text-blue-300">Reputation:</span>
-                        <span className="ml-2">{userProfile.reputation_score}</span>
-                      </div>
-                    </div>
-                  </div>
-                  {userProfile.user_role === 'seller' && (
-                    <div>
-                      <h3 className="font-semibold mb-2">Verkäufer-Status</h3>
-                      <div className="text-sm space-y-1">
-                        <div>
-                          <span className="text-blue-300">Abo-Tier:</span>
-                          <span className="ml-2 capitalize">{userProfile.subscription_tier}</span>
-                        </div>
-                        <div>
-                          <span className="text-blue-300">Status:</span>
-                          <span className={`ml-2 ${userProfile.subscription_active ? 'text-green-400' : 'text-red-400'}`}>
-                            {userProfile.subscription_active ? 'Aktiv' : 'Inaktiv'}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
+            userProfile.user_role === 'seller' ? (
+              <SellerDashboard userProfile={userProfile} />
+            ) : (
+              <BuyerDashboard userProfile={userProfile} />
+            )
           )}
         </div>
       </div>

--- a/src/components/EnhancedForumList.tsx
+++ b/src/components/EnhancedForumList.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { UserProfile } from "@/hooks/useAuth";
 import { supabase } from "@/integrations/supabase/client";
+import { NewPostDialog } from "./NewPostDialog";
 
 interface ForumPost {
   id: string;
@@ -47,6 +48,7 @@ export const EnhancedForumList = ({ userProfile }: EnhancedForumListProps) => {
   const [posts, setPosts] = useState<ForumPost[]>([]);
   const [categories, setCategories] = useState<ForumCategory[]>([]);
   const [loading, setLoading] = useState(true);
+  const [openNew, setOpenNew] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
   const [selectedPostType, setSelectedPostType] = useState<string>('all');
   const [selectedBorough, setSelectedBorough] = useState<string>(userProfile.borough || 'all');
@@ -193,7 +195,7 @@ export const EnhancedForumList = ({ userProfile }: EnhancedForumListProps) => {
                 Diskutiere mit deinem Kiez
               </CardDescription>
             </div>
-            <Button className="bg-blue-600 hover:bg-blue-700">
+            <Button className="bg-blue-600 hover:bg-blue-700" onClick={() => setOpenNew(true)}>
               <Plus className="h-4 w-4 mr-2" />
               Neuer Beitrag
             </Button>
@@ -326,6 +328,13 @@ export const EnhancedForumList = ({ userProfile }: EnhancedForumListProps) => {
           })
         )}
       </div>
+      <NewPostDialog
+        open={openNew}
+        onOpenChange={setOpenNew}
+        categories={categories}
+        userProfile={userProfile}
+        onCreated={fetchPosts}
+      />
     </div>
   );
 };

--- a/src/components/EventsCalendar.tsx
+++ b/src/components/EventsCalendar.tsx
@@ -18,9 +18,18 @@ export const EventsCalendar = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Since events table doesn't exist yet, show placeholder
-    setLoading(false);
-    // Future implementation will fetch from supabase when table is created
+    const loadEvents = async () => {
+      try {
+        const res = await fetch('/events.json');
+        const data = await res.json();
+        setEvents(data);
+      } catch (err) {
+        console.error('Failed to load events', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadEvents();
   }, [selectedDate]);
 
   const formatDate = (dateString: string | null) => {

--- a/src/components/NewPostDialog.tsx
+++ b/src/components/NewPostDialog.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import { supabase } from '@/integrations/supabase/client';
+import { UserProfile } from '@/hooks/useAuth';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  categories: { id: string; name: string }[];
+  onCreated?: () => void;
+  userProfile: UserProfile;
+}
+
+export const NewPostDialog = ({ open, onOpenChange, categories, onCreated, userProfile }: Props) => {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [category, setCategory] = useState<string>('');
+  const [type, setType] = useState<'offering' | 'searching' | 'discussion'>('discussion');
+
+  const createPost = async () => {
+    if (!title.trim() || !content.trim()) return;
+    await supabase.from('forum_posts').insert({
+      title,
+      content,
+      category_id: category || null,
+      post_type: type,
+      user_id: userProfile.id,
+      borough: userProfile.borough,
+    });
+    setTitle('');
+    setContent('');
+    setCategory('');
+    onOpenChange(false);
+    onCreated && onCreated();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-white/10 border-white/20 text-white">
+        <DialogHeader>
+          <DialogTitle>Neuen Beitrag erstellen</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Titel" className="bg-white/10 border-white/20" />
+          <Textarea value={content} onChange={(e) => setContent(e.target.value)} placeholder="Inhalt" className="bg-white/10 border-white/20" />
+          <Select value={category} onValueChange={(v) => setCategory(v)}>
+            <SelectTrigger className="bg-white/10 border-white/20">
+              <SelectValue placeholder="Kategorie" />
+            </SelectTrigger>
+            <SelectContent className="bg-slate-800 text-white">
+              <SelectItem value="">Keine</SelectItem>
+              {categories.map((c) => (
+                <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={type} onValueChange={(v) => setType(v as any)}>
+            <SelectTrigger className="bg-white/10 border-white/20">
+              <SelectValue placeholder="Typ" />
+            </SelectTrigger>
+            <SelectContent className="bg-slate-800 text-white">
+              <SelectItem value="offering">Bieten</SelectItem>
+              <SelectItem value="searching">Suchen</SelectItem>
+              <SelectItem value="discussion">Diskussion</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <DialogFooter>
+          <Button onClick={createPost} className="bg-blue-600 hover:bg-blue-700">Posten</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
## Summary
- add `scrape-events` npm script and placeholder event data
- create script to fetch events from berlin.de
- load events from `events.json` in the calendar
- implement dialog to create new forum posts
- show buyer or seller dashboard in the profile tab

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68482e960a748326864a06b84c82e2e4