### PR TITLE
Add reusable chat message service

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -10,6 +10,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { UserProfile } from "@/hooks/useAuth";
 import { supabase } from "@/integrations/supabase/client";
+import { sendChatMessage } from "@/services/sendChatMessage";
 
 interface ChatInterfaceProps {
   userProfile: UserProfile;
@@ -100,18 +101,11 @@ export const ChatInterface = ({ userProfile }: ChatInterfaceProps) => {
 
   const sendMessage = async () => {
     if (!message.trim() || !activeChat) return;
-    let anonymousName: string | null = null;
-    if (sendAnon) {
-      const { data } = await supabase.rpc('generate_anonymous_name');
-      anonymousName = data as string;
-    }
-
-    const { error } = await supabase.from('chat_messages').insert({
-      room_id: activeChat,
-      sender_id: userProfile.id,
+    const { error } = await sendChatMessage({
+      roomId: activeChat,
+      userId: userProfile.id,
       content: message,
-      is_anonymous: sendAnon,
-      anonymous_name: anonymousName,
+      isAnonymous: sendAnon,
     });
 
     if (!error) {

--- a/src/services/sendChatMessage.ts
+++ b/src/services/sendChatMessage.ts
@@ -1,0 +1,30 @@
+import { supabase } from '@/integrations/supabase/client';
+
+interface SendChatMessageParams {
+  roomId: string;
+  userId: string;
+  content: string;
+  isAnonymous: boolean;
+}
+
+export async function sendChatMessage({
+  roomId,
+  userId,
+  content,
+  isAnonymous,
+}: SendChatMessageParams) {
+  let anonymousName: string | null = null;
+
+  if (isAnonymous) {
+    const { data } = await supabase.rpc('generate_anonymous_name');
+    anonymousName = data as string;
+  }
+
+  return supabase.from('chat_messages').insert({
+    room_id: roomId,
+    sender_id: userId,
+    content,
+    is_anonymous: isAnonymous,
+    anonymous_name: anonymousName,
+  });
+}


### PR DESCRIPTION
## Summary
- provide `sendChatMessage` helper for inserting chat messages
- use new helper in `ChatInterface`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849d4f6f7208326b7343abd85dee340