### PR TITLE
Add ChatTest page with controlled anonymous sending

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import ProfilePage from "./pages/Profile";
 import NotFound from "./pages/NotFound";
+import ChatTest from "./pages/ChatTest";
 
 const queryClient = new QueryClient();
 
@@ -20,6 +21,7 @@ const App = () => (
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/profile" element={<ProfilePage />} />
+            <Route path="/chat-test" element={<ChatTest />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -13,6 +13,8 @@ import { supabase } from "@/integrations/supabase/client";
 
 interface ChatInterfaceProps {
   userProfile: UserProfile;
+  sendAnon?: boolean;
+  setSendAnon?: (v: boolean) => void;
 }
 
 interface ChatRoom {
@@ -33,7 +35,11 @@ interface ChatMessage {
   anonymous_name?: string | null;
 }
 
-export const ChatInterface = ({ userProfile }: ChatInterfaceProps) => {
+export const ChatInterface = ({
+  userProfile,
+  sendAnon: controlledSendAnon,
+  setSendAnon: controlledSetSendAnon,
+}: ChatInterfaceProps) => {
   const [message, setMessage] = useState('');
   const [activeChat, setActiveChat] = useState<string | null>(null);
   const [chats, setChats] = useState<ChatRoom[]>([]);
@@ -43,7 +49,9 @@ export const ChatInterface = ({ userProfile }: ChatInterfaceProps) => {
   const [newRoomDesc, setNewRoomDesc] = useState('');
   const [isTemporary, setIsTemporary] = useState(false);
   const [expiry, setExpiry] = useState<'24' | '48' | '72'>('24');
-  const [sendAnon, setSendAnon] = useState(false);
+  const [internalSendAnon, setInternalSendAnon] = useState(false);
+  const sendAnon = controlledSendAnon ?? internalSendAnon;
+  const setSendAnon = controlledSetSendAnon ?? setInternalSendAnon;
   const [channel, setChannel] = useState<RealtimeChannel | null>(null);
 
   useEffect(() => {

--- a/src/pages/ChatTest.tsx
+++ b/src/pages/ChatTest.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { ChatInterface } from '@/components/ChatInterface';
+import { useAuth, UserProfile } from '@/hooks/useAuth';
+import { Switch } from '@/components/ui/switch';
+
+const ChatTest = () => {
+  const { profile } = useAuth();
+  const [sendAnon, setSendAnon] = useState(false);
+
+  const mockProfile: UserProfile = {
+    id: 'mock-id',
+    email: 'mock@example.com',
+    nickname: 'Mock User',
+    user_role: 'buyer',
+    borough: 'Berlin',
+    subscription_tier: 'pro',
+    subscription_active: true,
+    verified_local: true,
+    reputation_score: 0,
+  };
+
+  const userProfile = profile || mockProfile;
+
+  return (
+    <div className="min-h-screen p-4 space-y-4 bg-gradient-to-br from-slate-900 via-blue-900 to-slate-800">
+      <div className="flex items-center space-x-2 text-white">
+        <Switch id="anon-toggle" checked={sendAnon} onCheckedChange={setSendAnon} />
+        <label htmlFor="anon-toggle">Anonymous</label>
+      </div>
+      <ChatInterface userProfile={userProfile} sendAnon={sendAnon} setSendAnon={setSendAnon} />
+    </div>
+  );
+};
+
+export default ChatTest;


### PR DESCRIPTION
## Summary
- allow external control of anonymous sending in `ChatInterface`
- add ChatTest page that toggles anonymous mode
- expose the page via `/chat-test` route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849d541b0188326971b88a76562737b