### PR TITLE
Fix message send handler

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -281,7 +281,18 @@ export const ChatInterface = ({ userProfile }: ChatInterfaceProps) => {
                   value={message}
                   onChange={(e) => setMessage(e.target.value)}
                   placeholder="Nachricht eingeben..."
-                  onKeyPress={(e) => e.key === 'Enter' && sendMessage()}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === 'Enter' &&
+                      !e.shiftKey &&
+                      !e.ctrlKey &&
+                      !e.altKey &&
+                      !e.metaKey
+                    ) {
+                      e.preventDefault();
+                      sendMessage();
+                    }
+                  }}
                   className="bg-white/10 border-white/20 text-white placeholder:text-white/50"
                 />
                 {(userProfile.subscription_tier === 'pro' || userProfile.subscription_tier === 'premium' || userProfile.user_role === 'seller') && (


### PR DESCRIPTION
## Summary
- send messages on Enter using onKeyDown
- ignore modifier keys so Shift+Enter etc. don't trigger send

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/berlin-kiez-talk/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_6849d55f3b048326b36d5fb9f61c60e4