### PR TITLE
Handle RLS errors when sending chat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Troubleshooting RLS errors
+
+When sending chat messages, the application relies on Supabase row level security (RLS) policies. If a message fails to send due to an RLS violation, check that the user is recorded in the `chat_participants` table for the room they are trying to message in. This is the most common cause of RLS errors.

--- a/src/services/sendChatMessage.ts
+++ b/src/services/sendChatMessage.ts
@@ -1,0 +1,32 @@
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "@/hooks/use-toast";
+
+export interface ChatMessageInsert {
+  room_id: string;
+  sender_id: string;
+  content: string;
+  is_anonymous?: boolean;
+  anonymous_name?: string | null;
+}
+
+/**
+ * Inserts a chat message into the database.
+ * Displays a toast if row level security prevents the insert.
+ */
+export async function sendChatMessage(message: ChatMessageInsert) {
+  const { error } = await supabase.from("chat_messages").insert(message);
+
+  if (error) {
+    // 42501 is the Postgres code for insufficient privilege / RLS violation
+    if (error.code === "42501") {
+      toast({
+        title: "Fehler",
+        description: "Du bist nicht berechtigt, in diesem Chat zu schreiben.",
+        variant: "destructive",
+      });
+      console.error("RLS violation while sending chat message:", error.details);
+    }
+  }
+
+  return { error };
+}


### PR DESCRIPTION
## Summary
- add `sendChatMessage` helper that shows a toast when RLS blocks an insert
- document common RLS issues in README

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849d5700b8c8326a394d8072ca324e5