### PR TITLE
Return full chat insert result

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -134,32 +134,22 @@ export const ChatInterface = ({
     return channel;
   };
 
-  // Update the sendMessage function in ChatInterface:
-const sendMessage = async () => {
-  if (!message.trim() || !activeChat) return;
-  
-  // Change this line:
-  const { error } = await sendChatMessage({
-    roomId: activeChat,
-    userId: userProfile.id,
-    content: message,
-    isAnonymous: sendAnon,
-  });
+  const sendMessage = async () => {
+    if (!message.trim() || !activeChat) return;
 
-  // To this:
-  const result = await sendChatMessage({
-    roomId: activeChat,
-    userId: userProfile.id,
-    content: message,
-    isAnonymous: sendAnon,
-  });
+    const result = await sendChatMessage({
+      roomId: activeChat,
+      userId: userProfile.id,
+      content: message,
+      isAnonymous: sendAnon,
+    });
 
-  if (!result.error) {
-    setMessage('');
-  } else {
-    console.error('sendMessage error', result.error);
-  }
-};
+    if (!result.error) {
+      setMessage('');
+    } else {
+      console.error('sendMessage error', result.error);
+    }
+  };
 
   const createRoom = async () => {
     if (!newRoomName.trim()) return;


### PR DESCRIPTION
## Summary
- return PostgREST insert response from `sendChatMessage`
- update call site in `ChatInterface`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ed6f737c8326857db51e5e02fa7d