### PR TITLE
Add noUncheckedIndexedAccess for tsconfigs

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,11 +15,13 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": false,
+    "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": false,
+
+    "noUncheckedIndexedAccess": true,
 
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "skipLibCheck": true,
     "allowJs": true,
     "noUnusedLocals": false,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true
   }
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -16,7 +16,8 @@
     "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- enable `noUncheckedIndexedAccess` for tsconfig files
- enable `strict` mode for the app tsconfig

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ab041a6748326ab54f11a25c2c6d6