### PR TITLE
Improve screen reader announcement of chat messages

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -520,7 +520,10 @@ export const ChatInterface = ({
             </div>
 
             {/* Messages */}
-            <div className="flex-1 overflow-y-auto p-4 space-y-4">
+            <div
+              className="flex-1 overflow-y-auto p-4 space-y-4"
+              aria-live="polite"
+            >
               {messages.length === 0 ? (
                 <div className="flex-1 flex items-center justify-center text-gray-400">
                   <div className="text-center">


### PR DESCRIPTION
## Summary
- add `aria-live="polite"` to the messages container in `ChatInterface`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa4da0d5c8326a697d0f277293c70