### PR TITLE
Add placeholder items to all Select components

### DIFF
--- a/src/components/AuthFlow.tsx
+++ b/src/components/AuthFlow.tsx
@@ -24,7 +24,7 @@ export const AuthFlow = () => {
     email: '',
     password: '',
     nickname: '',
-    borough: ''
+    borough: '__placeholder',
   });
 
   const { signIn, signUp } = useAuth();
@@ -190,6 +190,9 @@ export const AuthFlow = () => {
                       <SelectValue placeholder="Wählen Sie Ihren Bezirk" />
                     </SelectTrigger>
                     <SelectContent>
+                      <SelectItem value="__placeholder" disabled>
+                        Wählen Sie Ihren Bezirk
+                      </SelectItem>
                       {berlinBoroughs.map((borough) => (
                         <SelectItem key={borough} value={borough}>
                           {borough}

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -38,8 +38,12 @@ export const ChatInterface = ({
   const [newRoomName, setNewRoomName] = useState('');
   const [newRoomDesc, setNewRoomDesc] = useState('');
   const [isTemporary, setIsTemporary] = useState(false);
-  const [expiry, setExpiry] = useState<'24' | '48' | '72'>('24');
-  const [roomType, setRoomType] = useState<'group' | 'channel'>('group');
+  const [expiry, setExpiry] = useState<'__placeholder' | '24' | '48' | '72'>(
+    "__placeholder"
+  );
+  const [roomType, setRoomType] = useState<'__placeholder' | 'group' | 'channel'>(
+    "__placeholder"
+  );
   const [internalSendAnon, setInternalSendAnon] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const sendAnon = controlledSendAnon ?? internalSendAnon;
@@ -607,6 +611,9 @@ export const ChatInterface = ({
                 <SelectValue placeholder="Room type" />
               </SelectTrigger>
               <SelectContent className="bg-slate-800 border-slate-600 text-white">
+                <SelectItem value="__placeholder" disabled>
+                  Room type
+                </SelectItem>
                 <SelectItem value="group">Group Chat</SelectItem>
                 <SelectItem value="channel">Channel</SelectItem>
               </SelectContent>
@@ -622,11 +629,14 @@ export const ChatInterface = ({
                 <SelectTrigger className="bg-slate-700 border-slate-600 text-white">
                   <SelectValue placeholder="Expires in" />
                 </SelectTrigger>
-                <SelectContent className="bg-slate-800 border-slate-600 text-white">
+              <SelectContent className="bg-slate-800 border-slate-600 text-white">
+                  <SelectItem value="__placeholder" disabled>
+                    Expires in
+                  </SelectItem>
                   <SelectItem value="24">24 hours</SelectItem>
                   <SelectItem value="48">48 hours</SelectItem>
                   <SelectItem value="72">72 hours</SelectItem>
-                </SelectContent>
+              </SelectContent>
               </Select>
             )}
           </div>

--- a/src/components/EnhancedForumList.tsx
+++ b/src/components/EnhancedForumList.tsx
@@ -49,9 +49,9 @@ export const EnhancedForumList = ({ userProfile }: EnhancedForumListProps) => {
   const [categories, setCategories] = useState<ForumCategory[]>([]);
   const [loading, setLoading] = useState(true);
   const [openNew, setOpenNew] = useState(false);
-  const [selectedCategory, setSelectedCategory] = useState<string>('all');
-  const [selectedPostType, setSelectedPostType] = useState<string>('all');
-  const [selectedBorough, setSelectedBorough] = useState<string>(userProfile.borough || 'all');
+  const [selectedCategory, setSelectedCategory] = useState<string>("__placeholder");
+  const [selectedPostType, setSelectedPostType] = useState<string>("__placeholder");
+  const [selectedBorough, setSelectedBorough] = useState<string>("__placeholder");
   const [searchTerm, setSearchTerm] = useState('');
 
   const berlinBoroughs = [
@@ -210,6 +210,9 @@ export const EnhancedForumList = ({ userProfile }: EnhancedForumListProps) => {
                   <SelectValue placeholder="Kategorie wählen" />
                 </SelectTrigger>
                 <SelectContent className="bg-slate-800 border-slate-600">
+                  <SelectItem value="__placeholder" disabled>
+                    Kategorie wählen
+                  </SelectItem>
                   <SelectItem value="all" className="text-white hover:bg-slate-700">Alle Kategorien</SelectItem>
                   {categories.map((category) => (
                     <SelectItem key={category.id} value={category.id} className="text-white hover:bg-slate-700">
@@ -227,6 +230,9 @@ export const EnhancedForumList = ({ userProfile }: EnhancedForumListProps) => {
                   <SelectValue placeholder="Typ wählen" />
                 </SelectTrigger>
                 <SelectContent className="bg-slate-800 border-slate-600">
+                  <SelectItem value="__placeholder" disabled>
+                    Typ wählen
+                  </SelectItem>
                   <SelectItem value="all" className="text-white hover:bg-slate-700">Alle Typen</SelectItem>
                   {postTypes.map((type) => (
                     <SelectItem key={type.value} value={type.value} className="text-white hover:bg-slate-700">
@@ -244,6 +250,9 @@ export const EnhancedForumList = ({ userProfile }: EnhancedForumListProps) => {
                   <SelectValue placeholder="Bezirk wählen" />
                 </SelectTrigger>
                 <SelectContent className="bg-slate-800 border-slate-600">
+                  <SelectItem value="__placeholder" disabled>
+                    Bezirk wählen
+                  </SelectItem>
                   <SelectItem value="all" className="text-white hover:bg-slate-700">Alle Bezirke</SelectItem>
                   {berlinBoroughs.map((borough) => (
                     <SelectItem key={borough} value={borough} className="text-white hover:bg-slate-700">

--- a/src/components/EnhancedSellerProfiles.tsx
+++ b/src/components/EnhancedSellerProfiles.tsx
@@ -42,10 +42,10 @@ export const EnhancedSellerProfiles = ({ userProfile }: EnhancedSellerProfilesPr
   const [listings, setListings] = useState<SellerListing[]>([]);
   const [categories, setCategories] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selectedCategory, setSelectedCategory] = useState<string>('all');
-  const [selectedBorough, setSelectedBorough] = useState<string>(userProfile.borough || 'all');
+  const [selectedCategory, setSelectedCategory] = useState<string>("__placeholder");
+  const [selectedBorough, setSelectedBorough] = useState<string>("__placeholder");
   const [searchTerm, setSearchTerm] = useState('');
-  const [sortBy, setSortBy] = useState<string>('newest');
+  const [sortBy, setSortBy] = useState<string>("__placeholder");
 
   const berlinBoroughs = [
     'Mitte', 'Friedrichshain-Kreuzberg', 'Pankow', 'Charlottenburg-Wilmersdorf',
@@ -206,6 +206,9 @@ export const EnhancedSellerProfiles = ({ userProfile }: EnhancedSellerProfilesPr
                   <SelectValue placeholder="Kategorie wählen" />
                 </SelectTrigger>
                 <SelectContent className="bg-slate-800 border-slate-600">
+                  <SelectItem value="__placeholder" disabled>
+                    Kategorie wählen
+                  </SelectItem>
                   <SelectItem value="all" className="text-white hover:bg-slate-700">Alle Kategorien</SelectItem>
                   {categories.map((category) => (
                     <SelectItem key={category.id} value={category.id} className="text-white hover:bg-slate-700">
@@ -223,6 +226,9 @@ export const EnhancedSellerProfiles = ({ userProfile }: EnhancedSellerProfilesPr
                   <SelectValue placeholder="Bezirk wählen" />
                 </SelectTrigger>
                 <SelectContent className="bg-slate-800 border-slate-600">
+                  <SelectItem value="__placeholder" disabled>
+                    Bezirk wählen
+                  </SelectItem>
                   <SelectItem value="all" className="text-white hover:bg-slate-700">Alle Bezirke</SelectItem>
                   {berlinBoroughs.map((borough) => (
                     <SelectItem key={borough} value={borough} className="text-white hover:bg-slate-700">
@@ -240,6 +246,9 @@ export const EnhancedSellerProfiles = ({ userProfile }: EnhancedSellerProfilesPr
                   <SelectValue placeholder="Sortieren nach" />
                 </SelectTrigger>
                 <SelectContent className="bg-slate-800 border-slate-600">
+                  <SelectItem value="__placeholder" disabled>
+                    Sortieren nach
+                  </SelectItem>
                   <SelectItem value="newest" className="text-white hover:bg-slate-700">Neueste</SelectItem>
                   <SelectItem value="rating" className="text-white hover:bg-slate-700">Bewertung</SelectItem>
                   <SelectItem value="views" className="text-white hover:bg-slate-700">Aufrufe</SelectItem>

--- a/src/components/NewPostDialog.tsx
+++ b/src/components/NewPostDialog.tsx
@@ -18,8 +18,8 @@ interface Props {
 export const NewPostDialog = ({ open, onOpenChange, categories, onCreated, userProfile }: Props) => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [category, setCategory] = useState<string>('');
-  const [type, setType] = useState<'offering' | 'searching' | 'discussion'>('discussion');
+  const [category, setCategory] = useState<string>('__placeholder');
+  const [type, setType] = useState<'__placeholder' | 'offering' | 'searching' | 'discussion'>('__placeholder');
 
   const createPost = async () => {
     if (!title.trim() || !content.trim()) return;
@@ -52,6 +52,9 @@ export const NewPostDialog = ({ open, onOpenChange, categories, onCreated, userP
               <SelectValue placeholder="Kategorie" />
             </SelectTrigger>
             <SelectContent className="bg-slate-800 text-white">
+              <SelectItem value="__placeholder" disabled>
+                Kategorie
+              </SelectItem>
               <SelectItem value="">Keine</SelectItem>
               {categories.map((c) => (
                 <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
@@ -63,6 +66,9 @@ export const NewPostDialog = ({ open, onOpenChange, categories, onCreated, userP
               <SelectValue placeholder="Typ" />
             </SelectTrigger>
             <SelectContent className="bg-slate-800 text-white">
+              <SelectItem value="__placeholder" disabled>
+                Typ
+              </SelectItem>
               <SelectItem value="offering">Bieten</SelectItem>
               <SelectItem value="searching">Suchen</SelectItem>
               <SelectItem value="discussion">Diskussion</SelectItem>

--- a/src/components/SellerDashboard.tsx
+++ b/src/components/SellerDashboard.tsx
@@ -16,7 +16,7 @@ export const SellerDashboard = ({ userProfile }: SellerDashboardProps) => {
   const [views, setViews] = useState(0);
   const [reviews, setReviews] = useState(0);
   const [activeChats, setActiveChats] = useState(0);
-  const [tier, setTier] = useState<UserProfile["subscription_tier"]>(userProfile.subscription_tier);
+  const [tier, setTier] = useState<UserProfile["subscription_tier"] | "__placeholder">("__placeholder");
   const [active, setActive] = useState(userProfile.subscription_active);
   const { toast } = useToast();
 
@@ -94,6 +94,9 @@ export const SellerDashboard = ({ userProfile }: SellerDashboardProps) => {
                 <SelectValue placeholder="Tier" />
               </SelectTrigger>
               <SelectContent className="bg-slate-800 border-slate-600 text-white">
+                <SelectItem value="__placeholder" disabled>
+                  Tier
+                </SelectItem>
                 <SelectItem value="basic">basic</SelectItem>
                 <SelectItem value="pro">pro</SelectItem>
                 <SelectItem value="premium">premium</SelectItem>

--- a/src/components/events/EventFilters.tsx
+++ b/src/components/events/EventFilters.tsx
@@ -44,6 +44,9 @@ export const EventFilters = ({
           <SelectValue placeholder="Select Berlin area" />
         </SelectTrigger>
         <SelectContent>
+          <SelectItem value="__placeholder" disabled>
+            Select Berlin area
+          </SelectItem>
           <SelectItem value="all_areas">All areas</SelectItem>
           {availableAreas.map(area => (
             <SelectItem key={area} value={area}>{area}</SelectItem>


### PR DESCRIPTION
## Summary
- add disabled `SelectItem` placeholders for all `Select` components
- default Select state to `"__placeholder"` so Radix Select works with placeholders

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab1e75ad48326a28e90a81a17a573