### PR TITLE
Add contrast color tokens

### DIFF
--- a/src/components/AnnouncementsFeed.tsx
+++ b/src/components/AnnouncementsFeed.tsx
@@ -42,16 +42,16 @@ export const AnnouncementsFeed = () => {
             <CardTitle className="text-xl flex items-center">
               <Megaphone className="h-5 w-5 mr-2" /> Ankündigungen
             </CardTitle>
-            <CardDescription className="text-blue-200">
+            <CardDescription className="text-contrast-low">
               Wichtige Infos aus der Community
             </CardDescription>
           </div>
         </CardHeader>
         <CardContent className="space-y-4">
           {loading ? (
-            <div className="text-center text-blue-300 py-8">Lädt...</div>
+            <div className="text-center text-contrast-low py-8">Lädt...</div>
           ) : announcements.length === 0 ? (
-            <div className="text-center text-blue-300 py-8">
+            <div className="text-center text-contrast-low py-8">
               <p>Keine Ankündigungen verfügbar</p>
               <p className="text-sm mt-2 opacity-70">Diese Funktion wird bald verfügbar sein</p>
             </div>
@@ -59,12 +59,12 @@ export const AnnouncementsFeed = () => {
             announcements.map((ann) => (
               <Card key={ann.id} className="bg-white/5 text-white">
                 <CardContent className="p-4 space-y-2">
-                  <div className="flex items-center justify-between text-xs text-blue-300">
+                  <div className="flex items-center justify-between text-xs text-contrast-low">
                     <span>{ann.profile?.nickname || "System"}</span>
                     <span>{formatTimeAgo(ann.created_at)}</span>
                   </div>
                   <h3 className="font-semibold text-lg">{ann.title}</h3>
-                  <p className="text-sm text-blue-200 whitespace-pre-wrap">{ann.content}</p>
+                  <p className="text-sm text-contrast-low whitespace-pre-wrap">{ann.content}</p>
                 </CardContent>
               </Card>
             ))

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,9 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
 
+    --contrast-high: 222.2 47.4% 11.2%;
+    --contrast-low: 215.4 16.3% 56%;
+
     --radius: 0.5rem;
 
     --sidebar-background: 0 0% 98%;
@@ -81,6 +84,8 @@
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;
+    --contrast-high: 210 40% 98%;
+    --contrast-low: 215 20.2% 65.1%;
     --sidebar-background: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
     --sidebar-primary: 224.3 76.3% 48%;
@@ -98,6 +103,6 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground text-contrast-high;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -52,17 +52,21 @@ export default {
 					DEFAULT: 'hsl(var(--card))',
 					foreground: 'hsl(var(--card-foreground))'
 				},
-				sidebar: {
-					DEFAULT: 'hsl(var(--sidebar-background))',
-					foreground: 'hsl(var(--sidebar-foreground))',
-					primary: 'hsl(var(--sidebar-primary))',
-					'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-					accent: 'hsl(var(--sidebar-accent))',
-					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-					border: 'hsl(var(--sidebar-border))',
-					ring: 'hsl(var(--sidebar-ring))'
-				}
-			},
+                                sidebar: {
+                                        DEFAULT: 'hsl(var(--sidebar-background))',
+                                        foreground: 'hsl(var(--sidebar-foreground))',
+                                        primary: 'hsl(var(--sidebar-primary))',
+                                        'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+                                        accent: 'hsl(var(--sidebar-accent))',
+                                        'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+                                        border: 'hsl(var(--sidebar-border))',
+                                        ring: 'hsl(var(--sidebar-ring))'
+                                },
+                                contrast: {
+                                        high: 'hsl(var(--contrast-high))',
+                                        low: 'hsl(var(--contrast-low))'
+                                }
+                        },
 			borderRadius: {
 				lg: 'var(--radius)',
 				md: 'calc(var(--radius) - 2px)',


### PR DESCRIPTION
## Summary
- define --contrast-high and --contrast-low colors
- expose them in Tailwind theme
- apply high contrast color to body text
- use contrast-low in Announcements feed component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ab1ecd6c08326a888269f50d1fdac