### PR TITLE
Setup linting and formatting

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+if [ -z "$husky_skip_init" ]; then
+  debug() {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $*"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+  readonly husky_dir="$(dirname "$(dirname "$0")")"
+  readonly husky_run="$husky_dir/node_modules/husky/run"
+  if [ ! -f "$husky_run" ]; then
+    echo "can't find husky/run"
+    exit 0
+  fi
+  "$husky_run" "$hook_name" "$husky_dir" "$@"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "semi": true,
+  "printWidth": 80,
+  "tabWidth": 2
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import js from "@eslint/js";
 import globals from "globals";
+import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
@@ -7,23 +8,24 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   { ignores: ["dist"] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended, react.configs.recommended],
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {
+      react,
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
     },
     rules: {
+      ...react.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },
       ],
-      "@typescript-eslint/no-unused-vars": "off",
       // Disable rule causing errors with current eslint version
       "@typescript-eslint/no-unused-expressions": "off",
     },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
+    "prepare": "husky install",
     "scrape-events": "node ./scripts/scrapeBerlinEvents.js"
   },
   "dependencies": {
@@ -76,7 +77,11 @@
     "eslint": "^9.28.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
+    "eslint-plugin-react": "^7.36.0",
     "globals": "^15.9.0",
+    "husky": "^9.0.0",
+    "lint-staged": "^15.2.0",
+    "prettier": "^3.2.5",
     "lint": "^0.8.19",
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
@@ -84,5 +89,9 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"
+  },
+  "lint-staged": {
+    "*": "prettier --check",
+    "*.{js,jsx,ts,tsx}": "eslint"
   }
 }


### PR DESCRIPTION
## Summary
- add React linting presets and enable TS rules
- add Prettier configuration
- set up husky and lint-staged pre-commit hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx prettier --check .`

------
https://chatgpt.com/codex/tasks/task_e_684ab1f3ac3883269526fca65113e766