### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- add CI workflow running linting, type checking, tests and build on pull requests

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_684ab68796c8832692a68691ee57d5e8