### PR TITLE
Implement lazy loading for main pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,13 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { TestDataProvider } from "@/components/TestDataProvider";
-import Index from "./pages/Index";
-import ProfilePage from "./pages/Profile";
-import NotFound from "./pages/NotFound";
-import ChatTest from "./pages/ChatTest";
+import { Suspense, lazy } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const Index = lazy(() => import("./pages/Index"));
+const ProfilePage = lazy(() => import("./pages/Profile"));
+const NotFound = lazy(() => import("./pages/NotFound"));
+const ChatTest = lazy(() => import("./pages/ChatTest"));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -37,13 +40,21 @@ const App = () => (
           <Toaster />
           <Sonner />
           <BrowserRouter>
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/profile" element={<ProfilePage />} />
-              <Route path="/chat-test" element={<ChatTest />} />
-              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+            <Suspense
+              fallback={
+                <div className="p-4">
+                  <Skeleton className="w-full h-8" />
+                </div>
+              }
+            >
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/profile" element={<ProfilePage />} />
+                <Route path="/chat-test" element={<ChatTest />} />
+                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </Suspense>
           </BrowserRouter>
         </TooltipProvider>
       </TestDataProvider>

--- a/src/pages/ChatTest.tsx
+++ b/src/pages/ChatTest.tsx
@@ -1,7 +1,11 @@
-import { useState } from 'react';
-import { ChatInterface } from '@/components/ChatInterface';
+import { useState, Suspense, lazy } from 'react';
 import { useAuth, UserProfile } from '@/hooks/useAuth';
 import { Switch } from '@/components/ui/switch';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const ChatInterface = lazy(() =>
+  import('@/components/ChatInterface').then((m) => ({ default: m.ChatInterface }))
+);
 
 const ChatTest = () => {
   const { profile } = useAuth();
@@ -27,7 +31,19 @@ const ChatTest = () => {
         <Switch id="anon-toggle" checked={sendAnon} onCheckedChange={setSendAnon} />
         <label htmlFor="anon-toggle">Anonymous</label>
       </div>
-      <ChatInterface userProfile={userProfile} sendAnon={sendAnon} setSendAnon={setSendAnon} />
+      <Suspense
+        fallback={
+          <div className="p-4">
+            <Skeleton className="h-64 w-full" />
+          </div>
+        }
+      >
+        <ChatInterface
+          userProfile={userProfile}
+          sendAnon={sendAnon}
+          setSendAnon={setSendAnon}
+        />
+      </Suspense>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- lazy load main routes using `React.lazy`
- display skeletons with `<Suspense>`
- lazy load chat interface on chat test page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ab688bdb8832698a5714d30387797