### PR TITLE
Add basic vitest setup and component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "prepare": "husky install",
-    "scrape-events": "node ./scripts/scrapeBerlinEvents.js"
+    "scrape-events": "node ./scripts/scrapeBerlinEvents.js",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -88,7 +89,12 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.1",
+    "@testing-library/user-event": "^14.4.3",
+    "jsdom": "^24.0.0"
   },
   "lint-staged": {
     "*": "prettier --check",

--- a/src/components/__tests__/ChatInterface.test.tsx
+++ b/src/components/__tests__/ChatInterface.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ChatInterface } from '../ChatInterface';
+
+vi.mock('@/hooks/useChatRooms', () => ({
+  useChatRooms: () => ({ data: [], refetch: vi.fn() }),
+}));
+vi.mock('@/hooks/useRoomMessages', () => ({
+  useRoomMessages: () => ({ data: [], refetch: vi.fn() }),
+}));
+vi.mock('@/services/sendChatMessage', () => ({
+  sendChatMessage: vi.fn(),
+}));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+const userProfile = {
+  id: '1',
+  email: 'test@example.com',
+  nickname: null,
+  user_role: 'buyer',
+  borough: null,
+  subscription_tier: null,
+  subscription_active: null,
+  verified_local: null,
+  reputation_score: null,
+};
+
+describe('ChatInterface', () => {
+  it('renders placeholder when no chat is active', () => {
+    render(<ChatInterface userProfile={userProfile as any} />);
+    expect(screen.getByText('Welcome to KiezTalk')).toBeInTheDocument();
+  });
+});

--- a/src/utils/__tests__/dateUtils.test.ts
+++ b/src/utils/__tests__/dateUtils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  formatEventDate,
+  isToday,
+  isTomorrow,
+  getRelativeDateLabel,
+} from '../dateUtils';
+
+const today = new Date();
+const tomorrow = new Date(today);
+tomorrow.setDate(today.getDate() + 1);
+
+describe('date utils', () => {
+  it('detects today', () => {
+    const iso = today.toISOString();
+    expect(isToday(iso)).toBe(true);
+    expect(getRelativeDateLabel(iso)).toBe('Today');
+  });
+
+  it('detects tomorrow', () => {
+    const iso = tomorrow.toISOString();
+    expect(isTomorrow(iso)).toBe(true);
+    expect(getRelativeDateLabel(iso)).toBe('Tomorrow');
+  });
+
+  it('formats other dates', () => {
+    const other = new Date('2024-01-05T00:00:00Z');
+    const formatted = formatEventDate(other.toISOString());
+    expect(formatted).toMatch(/05\.01\.2024|05.01.2024/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts',
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// Basic Supabase client stub so components can import it in tests
+vi.mock('@/integrations/supabase/client', () => {
+  const mockFrom = vi.fn(() => ({
+    select: vi.fn().mockResolvedValue({ data: [], error: null }),
+    insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+    order: vi.fn(() => ({
+      select: vi.fn().mockResolvedValue({ data: [], error: null }),
+    })),
+  }));
+  return { supabase: { from: mockFrom } };
+});


### PR DESCRIPTION
## Summary
- add `vitest` test script and dev dependencies
- configure Vitest with React and jsdom
- stub Supabase client in test setup
- provide example utility and component tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab68967688326ba4e83322d0b8671