### PR TITLE
Wrap ChatInterface test with QueryClientProvider

### DIFF
--- a/src/components/__tests__/ChatInterface.test.tsx
+++ b/src/components/__tests__/ChatInterface.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ChatInterface } from '../ChatInterface';
 
 vi.mock('@/hooks/useChatRooms', () => ({
@@ -27,7 +28,12 @@ const userProfile = {
 
 describe('ChatInterface', () => {
   it('renders placeholder when no chat is active', () => {
-    render(<ChatInterface userProfile={userProfile as any} />);
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ChatInterface userProfile={userProfile as any} />
+      </QueryClientProvider>
+    );
     expect(screen.getByText('Welcome to KiezTalk')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- wrap `ChatInterface` test in `QueryClientProvider`

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest` *(fails: package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684accbfb0e88326b548898aaa4a8d90