### PR TITLE
Fix React JSX scope lint errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,8 @@ export default tseslint.config(
       ],
       // Disable rule causing errors with current eslint version
       "@typescript-eslint/no-unused-expressions": "off",
+      // Disable requirement for React to be in scope with JSX (React 17+)
+      "react/react-in-jsx-scope": "off",
     },
   }
 );


### PR DESCRIPTION
## Summary
- update ESLint configuration to disable react-in-jsx-scope rule

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad974a7d08326a3582b22930630ad