### PR TITLE
prefetch future events in calendar

### DIFF
--- a/src/components/EnhancedEventsCalendar.tsx
+++ b/src/components/EnhancedEventsCalendar.tsx
@@ -14,10 +14,7 @@ export const EnhancedEventsCalendar = () => {
   const { events, loading, selectedEvent, setSelectedEvent, loadEvents } = useEvents();
 
   useEffect(() => {
-    const dateStr = selectedDate
-      ? selectedDate.toISOString().split('T')[0]
-      : undefined;
-    loadEvents(dateStr ? { date: dateStr } : undefined);
+    loadEvents(selectedDate);
   }, [selectedDate]);
   
   // Get events for the selected date


### PR DESCRIPTION
## Summary
- prefetch events for the next two days when loading
- simplify `loadEvents` API to accept a `Date`
- prefetch when calendar date changes

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68527caceffc83269164b3436286e842