### PR TITLE
refactor: centralize formatEventDate utility

### DIFF
--- a/src/components/events/EventDetails.tsx
+++ b/src/components/events/EventDetails.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { StandardizedEvent } from '@/types/events';
-import { formatEventDate } from '@/utils/eventUtils';
+import { formatEventDate } from '@/utils/dateUtils';
 
 interface EventDetailsProps {
   selectedEvent: StandardizedEvent | null;

--- a/src/utils/eventUtils.ts
+++ b/src/utils/eventUtils.ts
@@ -64,23 +64,3 @@ export function generateEventTags(ev: TaggableEvent): string[] {
   return Array.from(new Set(tags)); // de-duplicate
 }
 
-/* ------------------------------------------------------------------ */
-/*  4. Date label helper                                              */
-/* ------------------------------------------------------------------ */
-
-export function formatEventDate(dateStr: string): string {
-  const date = new Date(dateStr);
-  const today = new Date();
-
-  if (date.toDateString() === today.toDateString()) return "Today";
-
-  const tomorrow = new Date(today);
-  tomorrow.setDate(today.getDate() + 1);
-  if (date.toDateString() === tomorrow.toDateString()) return "Tomorrow";
-
-  return date.toLocaleDateString("de-DE", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  });
-}


### PR DESCRIPTION
## Summary
- deduplicate `formatEventDate`
- import date helper from `dateUtils` in `EventDetails`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527d0d94148326aab3c74bdc17f812