### PR TITLE
Load events by date range

### DIFF
--- a/src/components/EnhancedEventsCalendar.tsx
+++ b/src/components/EnhancedEventsCalendar.tsx
@@ -30,15 +30,19 @@ export const EnhancedEventsCalendar = () => {
     selectedEvent,
     setSelectedEvent,
     loadEvents,
+    loadEventsByDateRange,
     filterEvents,
   } = useEvents();
 
   useEffect(() => {
-    const dateStr = selectedDate
-      ? selectedDate.toISOString().split('T')[0]
-      : undefined;
-    loadEvents({
-      date: dateStr,
+    if (!selectedDate) return;
+    const start = selectedDate.toISOString().split('T')[0];
+    const endDate = new Date(selectedDate);
+    endDate.setDate(selectedDate.getDate() + 7);
+    const end = endDate.toISOString().split('T')[0];
+    loadEventsByDateRange({
+      start,
+      end,
       area: selectedArea !== 'all_areas' ? selectedArea : undefined,
     });
   }, [selectedDate, selectedArea]);

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -73,6 +73,43 @@ export const useEvents = () => {
     }
   };
 
+  /** Load events within a specific date range */
+  const loadEventsByDateRange = async (opts: {
+    start: string;
+    end: string;
+    area?: string;
+  }) => {
+    const key = `dr:${opts.start}-${opts.end}-a:${opts.area ?? 'all'}`;
+    if (cacheRef.current[key]) {
+      setEvents(cacheRef.current[key]);
+      setFilteredEvents(cacheRef.current[key]);
+      if (!selectedEvent && cacheRef.current[key].length > 0) {
+        setSelectedEvent(cacheRef.current[key][0]);
+      }
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const rangeEvents = await eventsService.getEventsByDateRange(
+        opts.start,
+        opts.end,
+        opts.area,
+      );
+      cacheRef.current[key] = rangeEvents;
+      setEvents(rangeEvents);
+      setFilteredEvents(rangeEvents);
+
+      if (rangeEvents.length > 0 && !selectedEvent) {
+        setSelectedEvent(rangeEvents[0]);
+      }
+    } catch (err) {
+      console.error('Failed to load events in range', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const filterEvents = (filters: {
     searchTerm?: string;
     selectedTags?: string[];
@@ -129,6 +166,7 @@ export const useEvents = () => {
     selectedEvent,
     setSelectedEvent,
     loadEvents,
+    loadEventsByDateRange,
     filterEvents,
     getEventCountForDate,
   };


### PR DESCRIPTION
## Summary
- extend `useEvents` with `loadEventsByDateRange`
- update `EnhancedEventsCalendar` to request events for the next week

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68528b4916e88326ae9af920bc1d99f6