### PR TITLE
Add berlin_news table

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -51,6 +51,33 @@ export type Database = {
         }
         Relationships: []
       }
+      berlin_news: {
+        Row: {
+          id: string
+          title: string
+          content: string
+          created_at: string | null
+          borough: string | null
+          category: string | null
+        }
+        Insert: {
+          id?: string
+          title: string
+          content: string
+          created_at?: string | null
+          borough?: string | null
+          category?: string | null
+        }
+        Update: {
+          id?: string
+          title?: string
+          content?: string
+          created_at?: string | null
+          borough?: string | null
+          category?: string | null
+        }
+        Relationships: []
+      }
       chat_messages: {
         Row: {
           anonymous_name: string | null

--- a/supabase/migrations/20250623120000-berlin-news.sql
+++ b/supabase/migrations/20250623120000-berlin-news.sql
@@ -1,0 +1,33 @@
+-- Create table for Berlin news articles
+CREATE TABLE public.berlin_news (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  borough TEXT,
+  category TEXT
+);
+
+-- Enable RLS for berlin_news table
+ALTER TABLE public.berlin_news ENABLE ROW LEVEL SECURITY;
+
+-- Allow everyone to read news
+CREATE POLICY "Public can read news"
+  ON public.berlin_news
+  FOR SELECT
+  TO public
+  USING (true);
+
+-- Allow authenticated users to insert news
+CREATE POLICY "Authenticated users can insert news"
+  ON public.berlin_news
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (true);
+
+-- Allow authenticated users to update news
+CREATE POLICY "Authenticated users can update news"
+  ON public.berlin_news
+  FOR UPDATE
+  TO authenticated
+  USING (true);


### PR DESCRIPTION
## Summary
- add berlin_news table migration with RLS and policies
- update Supabase types with berlin_news

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685849b6a18c832693ed1a7e8735a0e4